### PR TITLE
Fixes to better support freezing

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -6,20 +6,11 @@ CairoSVG - A simple SVG converter based on Cairo.
 import os
 import sys
 from pathlib import Path
+from importlib import resources
 
-if hasattr(sys, 'frozen'):
-    if hasattr(sys, '_MEIPASS'):
-        # Frozen with PyInstaller
-        # See https://github.com/Kozea/WeasyPrint/pull/540
-        ROOT = Path(sys._MEIPASS) / 'cairosvg'
-    else:
-        # Frozen with something else (py2exe, etc.)
-        # See https://github.com/Kozea/WeasyPrint/pull/269
-        ROOT = Path(os.path.dirname(sys.executable))
-else:
-    ROOT = Path(os.path.dirname(__file__))
+ROOT = resources.files(__package__)
 
-VERSION = __version__ = (ROOT / 'VERSION').read_text().strip()
+VERSION = __version__ = ROOT.joinpath('VERSION').read_text().strip()
 
 
 # VERSION is used in the "url" module imported by "surface"

--- a/cairosvg/image.py
+++ b/cairosvg/image.py
@@ -6,7 +6,11 @@ Images manager.
 import os.path
 from io import BytesIO
 
-from PIL import Image, ImageOps
+try:
+    from PIL import Image, ImageOps
+except ImportError:
+    Image = None
+    ImageOps = None
 
 from .helpers import node_format, preserve_ratio, size
 from .parser import Tree
@@ -21,6 +25,8 @@ IMAGE_RENDERING = {
 
 def image(surface, node):
     """Draw an image ``node``."""
+    if Image is None:
+        raise RuntimeError("'Pillow' needs to be installed to render raster images.")
     base_url = node.get('{http://www.w3.org/XML/1998/namespace}base')
     if not base_url and node.url:
         base_url = os.path.dirname(node.url) + '/'
@@ -115,5 +121,7 @@ def image(surface, node):
 
 def invert_image(img):
     """Invert the colors of an image."""
+    if Image is None:
+        raise RuntimeError("'Pillow' needs to be installed to render raster images.")
     *rgb, a = img.convert('RGBA').split()
     return Image.merge('RGBA', (*map(ImageOps.invert, rgb), a))

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
   cssselect2
   defusedxml
   tinycss2
-python_requires = >= 3.5
+python_requires = >= 3.9
 
 [options.entry_points]
 console-scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
   cairocffi
   cssselect2
   defusedxml
-  pillow
   tinycss2
 python_requires = >= 3.5
 
@@ -58,6 +57,7 @@ console-scripts =
 cairosvg = VERSION
 
 [options.extras_require]
+raster = pillow
 doc =
   sphinx
   sphinx_rtd_theme


### PR DESCRIPTION
In order to better support freezing `CairoSVG` there are two changes I want to initially make:
- [X] Make `pillow` an optional dependency (reduces final package size)
- [x] Use `importlib.resources` to read the `VERSION` file (should be more resilient across multiple freezers/regular python use)

Since the main repository is not accepting PRs for features, these will live on my fork. The `freeze` branch will be my main branch for these changes, since that is what they are for. I may do tags as well, not sure yet.