### PR TITLE
Add importlib.resources fallback for VERSION

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -8,9 +8,12 @@ import sys
 from pathlib import Path
 from importlib import resources
 
-ROOT = resources.files(__package__)
+try:
+    ROOT = resources.files(__package__)
 
-VERSION = __version__ = ROOT.joinpath('VERSION').read_text().strip()
+    VERSION = __version__ = ROOT.joinpath('VERSION').read_text().strip()
+except (ValueError, AttributeError):
+    VERSION = __version__ = resources.read_text(__package__, 'VERSION').strip()
 
 
 # VERSION is used in the "url" module imported by "surface"

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
   cssselect2
   defusedxml
   tinycss2
-python_requires = >= 3.9
+python_requires = >= 3.7
 
 [options.entry_points]
 console-scripts =


### PR DESCRIPTION
Adding in this try/except block for finding the version fixes the issue I was seeing with PyOxidizer. PyOxidizer presents a `files` method, but it doesn't do anything so you end up with an error when you try to traverse the returned object.

Now if there are any problems getting the version, we fallback to the original importlib function. This also has the benefit of supporting Python 3.7 and up, rather than just 3.9 and up.